### PR TITLE
Remove redundant private method

### DIFF
--- a/test/lib/test/unit.rb
+++ b/test/lib/test/unit.rb
@@ -572,7 +572,6 @@ module Test
         end
       end
 
-      private
       def _run_suites(suites, type)
         result = super
         report.reject!{|r| r.start_with? "Skipped:" } if @options[:hide_skip]


### PR DESCRIPTION
There is already `private` on https://github.com/ruby/csv/blob/e0a25dbb268ad78d6c0f9f995cb05a8ef00437fc/test/lib/test/unit.rb#L558